### PR TITLE
feature/adds-crud-for-suggestion 

### DIFF
--- a/src/models/suggestion.ts
+++ b/src/models/suggestion.ts
@@ -9,7 +9,7 @@ export interface Suggestion extends Document {
 const SuggestionSchema: Schema<Suggestion> = new Schema({
   status: {
     type: Boolean,
-    default: true,
+    default: false,
   },
   name: {
     type: String,


### PR DESCRIPTION
* Define uma sugestão criada como falso, isso significa que o livro ainda não foi analisado por um administrador.